### PR TITLE
Destroy and cancel scenario

### DIFF
--- a/ios/Openid4vpBle/Openid4vpBle.swift
+++ b/ios/Openid4vpBle/Openid4vpBle.swift
@@ -67,10 +67,6 @@ class Openid4vpBle: RCTEventEmitter {
             callback([])
             print(">> raw message size", messageComponents[1].count)
             Wallet.shared.sendData(data: messageComponents[1])
-        case "onDisconnected":
-            callback([])
-            print("onDisconnected")
-            Wallet.shared.lookForDestroyConnection()
         default:
             print("DEFAULT SEND: MESSAGE:: ", message)
         }

--- a/ios/Wallet/Wallet.swift
+++ b/ios/Wallet/Wallet.swift
@@ -124,7 +124,9 @@ class Wallet: NSObject {
     
     func onDeviceDisconnected(isManualDisconnect: Bool) {
         if(!isManualDisconnect) {
-            central?.connectedPeripheral = nil
+            if let connectedPeripheral = central?.connectedPeripheral {
+                central?.centralManager.cancelPeripheralConnection(connectedPeripheral)
+            }
             EventEmitter.sharedInstance.emitNearbyEvent(event: "onDisconnected")
         }
     }

--- a/ios/ble/central/Central.swift
+++ b/ios/ble/central/Central.swift
@@ -6,8 +6,7 @@ import os
 class Central: NSObject, CBCentralManagerDelegate {
 
     var retryStrategy : BackOffStrategy = BackOffStrategy(MAX_RETRY_LIMIT: 10)
-
-    private var centralManager: CBCentralManager!
+    var centralManager: CBCentralManager!
     var connectedPeripheral: CBPeripheral?
     var cbCharacteristics: [String: CBCharacteristic] = [:]
 

--- a/ios/ble/central/CentralManagerDelegate.swift
+++ b/ios/ble/central/CentralManagerDelegate.swift
@@ -34,7 +34,7 @@ extension Central {
         if let connectedPeripheral = connectedPeripheral {
             central.cancelPeripheralConnection(connectedPeripheral)
         }
-        Wallet.shared.onDeviceDisconnected(isManualDisconnect: false)
+        Wallet.shared.destroyConnection()
     }
     
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {

--- a/ios/ble/central/PeripheralDelegate.swift
+++ b/ios/ble/central/PeripheralDelegate.swift
@@ -105,6 +105,7 @@ extension Central: CBPeripheralDelegate {
         } else if characteristic.uuid == NetworkCharNums.DISCONNECT_CHAR_UUID {
             let disconnectStatus = characteristic.value as Data?
             NotificationCenter.default.post(name: Notification.Name(rawValue: NotificationEvent.DISCONNECT_STATUS_CHANGE.rawValue), object: nil, userInfo: ["disconnectStatus": disconnectStatus])
+            peripheral.setNotifyValue(false, for: characteristic)
         }
     }
 


### PR DESCRIPTION
## What?
To destroy and cancel the connection
## Why?
To remove the peripheral and make the device ready for next connection
## How?
Added cancel peripheral delegate and check for destroy happening in higher level 
## Testing?
1. Disconnection on successful VC transfer
2. Disconnection on closing Verifier/Wallet app
3. Disconnection on clicking cancel button on Verifier
4. Disconnection on Accepting/Discarding/Reject VC

## Anything Else?