### PR TITLE
Destroy connection on transfer complete

### DIFF
--- a/ios/Openid4vpBle/Openid4vpBle.swift
+++ b/ios/Openid4vpBle/Openid4vpBle.swift
@@ -57,7 +57,8 @@ class Openid4vpBle: RCTEventEmitter {
 
     @objc(destroyConnection:)
     func destroyConnection(withCallback callback: @escaping RCTResponseSenderBlock) -> Any {
-        Wallet.shared.destroyConnection()
+        Wallet.shared.destroyConnection(isManualDisconnect: true)
+        callback([])
         return "check" as! Any
     }
 
@@ -113,7 +114,7 @@ class Openid4vpBle: RCTEventEmitter {
     }
 
     fileprivate func handleError(_ message: String) {
-        Wallet.shared.destroyConnection()
+        Wallet.shared.destroyConnection(isManualDisconnect: false)
         EventEmitter.sharedInstance.emitNearbyErrorEvent(message: message)
     }
 

--- a/ios/Openid4vpBle/Openid4vpBle.swift
+++ b/ios/Openid4vpBle/Openid4vpBle.swift
@@ -57,7 +57,7 @@ class Openid4vpBle: RCTEventEmitter {
 
     @objc(destroyConnection:)
     func destroyConnection(withCallback callback: @escaping RCTResponseSenderBlock) -> Any {
-        Wallet.shared.destroyConnection(isManualDisconnect: true)
+        Wallet.shared.destroyConnection(isSelfDisconnect: true)
         callback([])
         return "check" as! Any
     }
@@ -114,7 +114,7 @@ class Openid4vpBle: RCTEventEmitter {
     }
 
     fileprivate func handleError(_ message: String) {
-        Wallet.shared.destroyConnection(isManualDisconnect: false)
+        Wallet.shared.destroyConnection(isSelfDisconnect: false)
         EventEmitter.sharedInstance.emitNearbyErrorEvent(message: message)
     }
 

--- a/ios/Wallet/Wallet.swift
+++ b/ios/Wallet/Wallet.swift
@@ -30,8 +30,8 @@ class Wallet: NSObject {
         verifierPublicKey = publicKeyData
     }
 
-    func destroyConnection(){
-        onDeviceDisconnected(isManualDisconnect: false)
+    func destroyConnection(isManualDisconnect: Bool){
+        onDeviceDisconnected(isManualDisconnect: isManualDisconnect)
     }
 
     func isSameAdvIdentifier(advertisementPayload: Data) -> Bool {
@@ -98,10 +98,10 @@ class Wallet: NSObject {
     }
 
     func onDeviceDisconnected(isManualDisconnect: Bool) {
+        if let connectedPeripheral = central?.connectedPeripheral {
+            central?.centralManager.cancelPeripheralConnection(connectedPeripheral)
+        }
         if(!isManualDisconnect) {
-            if let connectedPeripheral = central?.connectedPeripheral {
-                central?.centralManager.cancelPeripheralConnection(connectedPeripheral)
-            }
             EventEmitter.sharedInstance.emitNearbyEvent(event: "onDisconnected")
         }
     }
@@ -118,7 +118,7 @@ extension Wallet: WalletProtocol {
             let connStatusID = Int(data[0])
             if connStatusID == 1 {
                 print("con statusid:", connStatusID)
-                destroyConnection()
+                destroyConnection(isManualDisconnect: false)
             }
         } else {
             print("weird reason!!")

--- a/ios/Wallet/Wallet.swift
+++ b/ios/Wallet/Wallet.swift
@@ -30,8 +30,8 @@ class Wallet: NSObject {
         verifierPublicKey = publicKeyData
     }
 
-    func destroyConnection(isManualDisconnect: Bool){
-        onDeviceDisconnected(isManualDisconnect: isManualDisconnect)
+    func destroyConnection(isSelfDisconnect: Bool){
+        onDeviceDisconnected(isSelfDisconnect: isSelfDisconnect)
     }
 
     func isSameAdvIdentifier(advertisementPayload: Data) -> Bool {
@@ -97,11 +97,11 @@ class Wallet: NSObject {
         central?.write(serviceUuid: Peripheral.SERVICE_UUID, charUUID: NetworkCharNums.IDENTIFY_REQUEST_CHAR_UUID, data: iv + publicKey)
     }
 
-    func onDeviceDisconnected(isManualDisconnect: Bool) {
+    func onDeviceDisconnected(isSelfDisconnect: Bool) {
         if let connectedPeripheral = central?.connectedPeripheral {
             central?.centralManager.cancelPeripheralConnection(connectedPeripheral)
         }
-        if(!isManualDisconnect) {
+        if(!isSelfDisconnect) {
             EventEmitter.sharedInstance.emitNearbyEvent(event: "onDisconnected")
         }
     }
@@ -118,7 +118,7 @@ extension Wallet: WalletProtocol {
             let connStatusID = Int(data[0])
             if connStatusID == 1 {
                 print("con statusid:", connStatusID)
-                destroyConnection(isManualDisconnect: false)
+                destroyConnection(isSelfDisconnect: false)
             }
         } else {
             print("weird reason!!")

--- a/ios/ble/Utility/TransferHandler.swift
+++ b/ios/ble/Utility/TransferHandler.swift
@@ -90,6 +90,7 @@ class TransferHandler {
         if (r.type == .SUCCESS) {
             currentState = States.TransferVerified
             EventEmitter.sharedInstance.emitNearbyMessage(event: "send-vc:response", data: "\"RECEIVED\"")
+            sendMessage(message: imessage(msgType: .RESPONSE_TRANSFER_COMPLETE))
             print("Emitting send-vc:response RECEIVED message")
         } else if r.type == .MISSING_CHUNKS {
             currentState = .PartiallyTransferred
@@ -193,6 +194,7 @@ extension TransferHandler: PeripheralCommunicatorProtocol {
             } else if status == 1 {
                 EventEmitter.sharedInstance.emitNearbyMessage(event: "send-vc:response", data: "\"REJECTED\"")
             }
+            Wallet.shared.destroyConnection(isManualDisconnect: true)
         }
     }
 }

--- a/ios/ble/Utility/TransferHandler.swift
+++ b/ios/ble/Utility/TransferHandler.swift
@@ -194,7 +194,7 @@ extension TransferHandler: PeripheralCommunicatorProtocol {
             } else if status == 1 {
                 EventEmitter.sharedInstance.emitNearbyMessage(event: "send-vc:response", data: "\"REJECTED\"")
             }
-            Wallet.shared.destroyConnection(isManualDisconnect: true)
+            Wallet.shared.destroyConnection(isSelfDisconnect: true)
         }
     }
 }

--- a/ios/ble/central/CentralManagerDelegate.swift
+++ b/ios/ble/central/CentralManagerDelegate.swift
@@ -34,7 +34,7 @@ extension Central {
         if let connectedPeripheral = connectedPeripheral {
             central.cancelPeripheralConnection(connectedPeripheral)
         }
-        Wallet.shared.destroyConnection()
+        Wallet.shared.destroyConnection(isManualDisconnect: false)
     }
     
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {

--- a/ios/ble/central/CentralManagerDelegate.swift
+++ b/ios/ble/central/CentralManagerDelegate.swift
@@ -34,7 +34,7 @@ extension Central {
         if let connectedPeripheral = connectedPeripheral {
             central.cancelPeripheralConnection(connectedPeripheral)
         }
-        Wallet.shared.destroyConnection(isManualDisconnect: false)
+        Wallet.shared.destroyConnection(isSelfDisconnect: false)
     }
     
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {


### PR DESCRIPTION
## What?
To destroy the connection when the UI response captured from User on success / failure

## Why?
To remove the peripheral and make the device ready for next connection

## How?
Added is selfdisconnect and trigger it when the emitter responds

## Testing?
1. Disconnection on successful VC transfer
2. Disconnection on closing Verifier/Wallet app
3. Disconnection on clicking cancel button on Verifier
4. Disconnection on Accepting/Discarding/Reject VC

## Anything Else?

**Issue Link :** https://github.com/mosip/inji/issues/593