### PR TITLE
fix(#598): [Vijay] fix incorrect device name labels in iOS

### DIFF
--- a/ios/Wallet/Wallet.swift
+++ b/ios/Wallet/Wallet.swift
@@ -11,7 +11,7 @@ class Wallet: NSObject {
     var cryptoBox: WalletCryptoBox = WalletCryptoBoxBuilder().build()
     var advIdentifier: String?
     var verifierPublicKey: Data?
-    static let EXCHANGE_RECEIVER_INFO_DATA = "{\"deviceName\":\"wallet\"}"
+    static let EXCHANGE_RECEIVER_INFO_DATA = "{\"deviceName\":\"Verifier\"}"
 
     private override init() {
         super.init()


### PR DESCRIPTION
fix incorrect device name ( "Verifier" instead of "Wallet") labels in iOS