### PR TITLE
feat(#627): handle update 5 retry frames on android wallet

### DIFF
--- a/android/src/main/java/io/mosip/tuvali/wallet/Wallet.kt
+++ b/android/src/main/java/io/mosip/tuvali/wallet/Wallet.kt
@@ -28,6 +28,7 @@ import org.bouncycastle.util.encoders.Hex
 import java.security.SecureRandom
 import java.util.*
 import io.mosip.tuvali.transfer.Util.Companion.getLogTag
+import io.mosip.tuvali.wallet.exception.TransferFailedException
 
 private const val MTU_REQUEST_RETRY_DELAY_TIME_IN_MILLIS = 500L
 
@@ -270,7 +271,7 @@ class Wallet(
   }
 
   override fun onResponseSendFailure(errorMsg: String) {
-    // TODO: Handle error
+    throw TransferFailedException(errorMsg)
   }
 
   override fun onNotificationReceived(charUUID: UUID, value: ByteArray?) {

--- a/android/src/main/java/io/mosip/tuvali/wallet/exception/MTUNegotiationFailedException.kt
+++ b/android/src/main/java/io/mosip/tuvali/wallet/exception/MTUNegotiationFailedException.kt
@@ -1,5 +1,3 @@
 package io.mosip.tuvali.wallet.exception
 
-import io.mosip.tuvali.verifier.exception.VerifierException
-
-class MTUNegotiationFailedException(s: String) : VerifierException(s)
+class MTUNegotiationFailedException(s: String) : WalletException(s)

--- a/android/src/main/java/io/mosip/tuvali/wallet/exception/TransferFailedException.kt
+++ b/android/src/main/java/io/mosip/tuvali/wallet/exception/TransferFailedException.kt
@@ -1,0 +1,3 @@
+package io.mosip.tuvali.wallet.exception
+
+class TransferFailedException(s: String) : WalletException(s)

--- a/android/src/main/java/io/mosip/tuvali/wallet/exception/WalletException.kt
+++ b/android/src/main/java/io/mosip/tuvali/wallet/exception/WalletException.kt
@@ -1,3 +1,3 @@
 package io.mosip.tuvali.wallet.exception
 
-class WalletException(message: String): Throwable(message)
+open class WalletException(message: String): Throwable(message)

--- a/android/src/main/java/io/mosip/tuvali/wallet/transfer/TransferHandler.kt
+++ b/android/src/main/java/io/mosip/tuvali/wallet/transfer/TransferHandler.kt
@@ -12,14 +12,14 @@ import io.mosip.tuvali.wallet.transfer.message.*
 import java.util.*
 import io.mosip.tuvali.transfer.Util.Companion.getLogTag
 
-const val MAXIMUM_RETRY_FRAME_LIMIT = 5;
+const val MAX_FAILURE_FRAME_RETRY_LIMIT = 5;
 
 class TransferHandler(looper: Looper, private val central: Central, val serviceUUID: UUID, private val transferListener: ITransferListener) :
   Handler(looper) {
   private lateinit var retryChunker: RetryChunker
   private val logTag = getLogTag(javaClass.simpleName)
   private var chunkCounter = 0;
-  private var retryCounter = 0;
+  private var failureFrameRetryCounter = 0;
 
   enum class States {
     UnInitialised,
@@ -82,7 +82,7 @@ class TransferHandler(looper: Looper, private val central: Central, val serviceU
         handleTransmissionReport(handleTransmissionReportMessage.report)
       }
       IMessage.TransferMessageTypes.RESPONSE_CHUNK_WRITE_SUCCESS.ordinal -> {
-        if(retryCounter > 0) {
+        if(failureFrameRetryCounter > 0) {
           sendRetryResponseChunk()
         } else {
           sendResponseChunk()
@@ -106,7 +106,7 @@ class TransferHandler(looper: Looper, private val central: Central, val serviceU
       }
       IMessage.TransferMessageTypes.INIT_RETRY_TRANSFER.ordinal -> {
         val initRetryTransferMessage = msg.obj as InitRetryTransferMessage
-        retryCounter++;
+        failureFrameRetryCounter++;
         retryChunker = RetryChunker(chunker!!, initRetryTransferMessage.missedSequences)
         sendRetryResponseChunk()
       }
@@ -125,18 +125,17 @@ class TransferHandler(looper: Looper, private val central: Central, val serviceU
     if (report.type == TransferReport.ReportType.SUCCESS) {
       currentState = States.TransferVerified
       transferListener.onResponseSent()
-      //Log.d(logTag, "handleMessage: Successfully transferred vc in ${System.currentTimeMillis() - responseStartTimeInMillis}ms")
     } else if(report.type == TransferReport.ReportType.MISSING_CHUNKS && report.missingSequences != null) {
       currentState = States.PartiallyTransferred
 
-      if(retryCounter >= MAXIMUM_RETRY_FRAME_LIMIT) {
-        this.sendMessage(ResponseTransferFailureMessage("Reached Retry Limit"))
+      if(failureFrameRetryCounter >= MAX_FAILURE_FRAME_RETRY_LIMIT) {
+        this.sendMessage(ResponseTransferFailureMessage("Failure frame retry limit of $failureFrameRetryCounter reached"))
         return
       }
 
       this.sendMessage(InitRetryTransferMessage(report.missingSequences))
     } else {
-      this.sendMessage(ResponseTransferFailureMessage("Invalid Report"))
+      this.sendMessage(ResponseTransferFailureMessage("Invalid Transfer Report"))
     }
   }
 

--- a/ios/Openid4vpBle/Error/OpenId4vpError.swift
+++ b/ios/Openid4vpBle/Error/OpenId4vpError.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum OpenId4vpError: Error {
     case invalidMTUSizeError(mtu: Int)
+    case responseTransferFailure
 }
 
 extension OpenId4vpError: CustomStringConvertible {
@@ -9,6 +10,8 @@ extension OpenId4vpError: CustomStringConvertible {
         switch self {
         case .invalidMTUSizeError(let mtu):
             return "Negotiated MTU: \(mtu) is too low."
+        case .responseTransferFailure:
+            return "failed to write response"
         }
     }
 }

--- a/ios/Openid4vpBle/Openid4vpBle.swift
+++ b/ios/Openid4vpBle/Openid4vpBle.swift
@@ -27,8 +27,8 @@ class Openid4vpBle: RCTEventEmitter {
         let publicKey = connectionParameter["pk"] as? String
         print("synchronized setConnectionParameters called with", params, "and", publicKey)
         wallet = Wallet()
-        if let privateKey {
-            wallet?.setAdvIdentifier(identifier: privateKey)
+        if let publicKey {
+            wallet?.setAdvIdentifier(identifier: publicKey)
         }
         return "data" as Any
     }

--- a/ios/ble/Utility/TransferHandler.swift
+++ b/ios/ble/Utility/TransferHandler.swift
@@ -8,8 +8,8 @@ class TransferHandler {
     private var responseStartTimeInMillis: UInt64 = 0
     private var chunker: Chunker?
     var destroyConnection: (() -> Void)?
-    private var retryCount = 0
-    private let MAXIMUM_RETRY_FRAME_LIMIT = 5
+    private var failureFrameRetryCounter = 0
+    private let MAX_FAILURE_FRAME_RETRY_LIMIT = 5
     
     func initialize(initdData: Data) {
         data = initdData
@@ -92,19 +92,19 @@ class TransferHandler {
         if (r.type == .SUCCESS) {
             currentState = States.TransferVerified
             EventEmitter.sharedInstance.emitNearbyMessage(event: "send-vc:response", data: "\"RECEIVED\"")
-            retryCount = 0
+            failureFrameRetryCounter = 0
             os_log(.info, "Emitting send-vc:response RECEIVED message")
         } else if r.type == .MISSING_CHUNKS {
             currentState = .PartiallyTransferred
-            retryCount+=1
-            if (retryCount >= MAXIMUM_RETRY_FRAME_LIMIT) {
+            if (failureFrameRetryCounter >= MAX_FAILURE_FRAME_RETRY_LIMIT) {
                 sendMessage(message: imessage(msgType: .RESPONSE_TRANSFER_FAILED))
             } else {
+                failureFrameRetryCounter+=1
                 sendRetryRespChunk(missingChunks: r.missingSequences!)
             }
         } else {
             os_log(.info, "handle transfer report parsing, report-type= %{public}d", r.type.rawValue)
-            retryCount = 0
+            failureFrameRetryCounter = 0
             sendMessage(message: imessage(msgType: .RESPONSE_TRANSFER_FAILED, data: nil, dataSize: 0))
         }
     }

--- a/ios/ble/Utility/TransferHandler.swift
+++ b/ios/ble/Utility/TransferHandler.swift
@@ -8,7 +8,9 @@ class TransferHandler {
     private var responseStartTimeInMillis: UInt64 = 0
     private var chunker: Chunker?
     var destroyConnection: (() -> Void)?
-
+    private var retryCount = 0
+    private let MAXIMUM_RETRY_FRAME_LIMIT = 5
+    
     func initialize(initdData: Data) {
         data = initdData
     }
@@ -60,6 +62,7 @@ class TransferHandler {
             sendMessage(message: imessage(msgType: .READ_TRANSMISSION_REPORT))
         } else if msg.msgType == .RESPONSE_TRANSFER_FAILED {
             currentState = States.ResponseWriteFailed
+            ErrorHandler.sharedInstance.handle(error: OpenId4vpError.responseTransferFailure)
         } else {
             os_log(.error, "Out of scope")
         }
@@ -89,12 +92,19 @@ class TransferHandler {
         if (r.type == .SUCCESS) {
             currentState = States.TransferVerified
             EventEmitter.sharedInstance.emitNearbyMessage(event: "send-vc:response", data: "\"RECEIVED\"")
+            retryCount = 0
             os_log(.info, "Emitting send-vc:response RECEIVED message")
         } else if r.type == .MISSING_CHUNKS {
             currentState = .PartiallyTransferred
-            sendRetryRespChunk(missingChunks: r.missingSequences!)
+            retryCount+=1
+            if (retryCount >= MAXIMUM_RETRY_FRAME_LIMIT) {
+                sendMessage(message: imessage(msgType: .RESPONSE_TRANSFER_FAILED))
+            } else {
+                sendRetryRespChunk(missingChunks: r.missingSequences!)
+            }
         } else {
             os_log(.info, "handle transfer report parsing, report-type= %{public}d", r.type.rawValue)
+            retryCount = 0
             sendMessage(message: imessage(msgType: .RESPONSE_TRANSFER_FAILED, data: nil, dataSize: 0))
         }
     }


### PR DESCRIPTION
When the Missed Chunks report gets shown for the 5th time, this error message is shown on iPhone(green, up) and Android(black, down)

![image](https://user-images.githubusercontent.com/9304050/224706947-b12874f8-1e47-4867-8d78-cbee704e0b89.png)
