### PR TITLE
feat: Android13(Pixel6) compatibility & bump up failure frames to 15

### DIFF
--- a/android/src/main/java/io/mosip/tuvali/ble/peripheral/impl/GattServer.kt
+++ b/android/src/main/java/io/mosip/tuvali/ble/peripheral/impl/GattServer.kt
@@ -8,6 +8,10 @@ import android.util.Log
 import java.util.UUID
 import io.mosip.tuvali.transfer.Util.Companion.getLogTag
 
+//Set maximum attribute value as defined by spec Core 5.3
+//https://github.com/dariuszseweryn/RxAndroidBle/pull/808
+private const val MAX_ALLOWED_MTU_VALUE = 512
+
 @SuppressLint("MissingPermission")
 class GattServer(private val context: Context) : BluetoothGattServerCallback() {
   private val logTag = getLogTag(javaClass.simpleName)
@@ -80,7 +84,13 @@ class GattServer(private val context: Context) : BluetoothGattServerCallback() {
 
   override fun onMtuChanged(device: BluetoothDevice?, mtu: Int) {
     Log.d(logTag, "onMtuChanged: mtu: $mtu, device: $device")
-    onMTUChangedCallback(mtu)
+    var allowedMTU = mtu
+    // follow BLE 5.3 spec where max data size in a chunk is limited to 512 to make it compatible to Android 13
+    if(mtu > MAX_ALLOWED_MTU_VALUE) {
+      allowedMTU = MAX_ALLOWED_MTU_VALUE
+      Log.d(logTag, "Allowed MTU value is changed from $mtu to $allowedMTU")
+    }
+    onMTUChangedCallback(allowedMTU)
   }
 
   private fun setPhy(bluetoothDevice: BluetoothDevice) {

--- a/android/src/main/java/io/mosip/tuvali/wallet/transfer/TransferHandler.kt
+++ b/android/src/main/java/io/mosip/tuvali/wallet/transfer/TransferHandler.kt
@@ -12,7 +12,7 @@ import io.mosip.tuvali.wallet.transfer.message.*
 import java.util.*
 import io.mosip.tuvali.transfer.Util.Companion.getLogTag
 
-const val MAX_FAILURE_FRAME_RETRY_LIMIT = 5;
+const val MAX_FAILURE_FRAME_RETRY_LIMIT = 15
 
 class TransferHandler(looper: Looper, private val central: Central, val serviceUUID: UUID, private val transferListener: ITransferListener) :
   Handler(looper) {

--- a/ios/Wallet/Wallet.swift
+++ b/ios/Wallet/Wallet.swift
@@ -93,6 +93,11 @@ class Wallet: NSObject {
                 if currentMTUSize == nil || currentMTUSize! < 0 {
                    currentMTUSize = BLEConstants.DEFAULT_CHUNK_SIZE
                 }
+                // follow BLE 5.3 spec where max data size in a chunk is limited to 512
+                // now iOS impl is compatible to Android13 which follows BLE5.3 spec more closely
+                if currentMTUSize > BLEConstants.MAX_ALLOWED_DATA_LEN {
+                    currentMTUSize = BLEConstants.MAX_ALLOWED_DATA_LEN
+                }
                 let imsgBuilder = imessage(msgType: .INIT_RESPONSE_TRANSFER, data: encryptedData!, mtuSize: currentMTUSize)
                 transferHandler.sendMessage(message: imsgBuilder)
             }

--- a/ios/ble/Utility/BLEConstants.swift
+++ b/ios/ble/Utility/BLEConstants.swift
@@ -10,4 +10,8 @@ struct BLEConstants {
     static var seqNumberReservedByteSize = 2
     static var mtuReservedByteSize = 2
     static let EXCHANGE_RECEIVER_INFO_DATA = "{\"deviceName\":\"Verifier\"}"
+    // Set maximum attribute value as defined by spec Core 5.3
+    // ref: https://github.com/dariuszseweryn/RxAndroidBle/pull/808
+    // TODO: decide if this should be bumped up to 512
+    static let MAX_ALLOWED_DATA_LEN = 509
 }

--- a/ios/ble/Utility/TransferHandler.swift
+++ b/ios/ble/Utility/TransferHandler.swift
@@ -27,7 +27,6 @@ class TransferHandler {
             var responseData = msg.data!
             os_log(.info, "Total response size of data %{public}d",(responseData.count))
             chunker = Chunker(chunkData: responseData, mtuSize: msg.mtuSize)
-            os_log(.info, "MTU found to be %{public}d", BLEConstants.DEFAULT_CHUNK_SIZE)
             currentState = States.ResponseSizeWritePending
             sendMessage(message: imessage(msgType: .RESPONSE_SIZE_WRITE_PENDING, data: responseData, dataSize: responseData.count))
         }

--- a/ios/ble/Utility/TransferHandler.swift
+++ b/ios/ble/Utility/TransferHandler.swift
@@ -9,8 +9,8 @@ class TransferHandler {
     private var chunker: Chunker?
     var destroyConnection: (() -> Void)?
     private var failureFrameRetryCounter = 0
-    private let MAX_FAILURE_FRAME_RETRY_LIMIT = 5
-    
+    private let MAX_FAILURE_FRAME_RETRY_LIMIT = 15
+
     func initialize(initdData: Data) {
         data = initdData
     }


### PR DESCRIPTION
Addresses two issues: 668 & 665

**Testing details**:

- 665: been tested against iPhone 12 mini(iOS 16) --> Pixel6(Android 13), _we'd like to test it again against a non-Google phone as a verifier to validate if the behaviour of dropping two bytes is an issue specific to Google while we have reasons to believe this is a good-to-have-fix_
- 668: tested against iPhone7 & Redmi7A day before yesterday(we've seen 20 failure frames at max, so 15 should be a good to have limit)