### PR TITLE
fix(INJI-39): skip request for PHY upgrade to PHY2 [ Develop ]

### DIFF
--- a/android/src/main/java/io/mosip/tuvali/ble/central/impl/GattClient.kt
+++ b/android/src/main/java/io/mosip/tuvali/ble/central/impl/GattClient.kt
@@ -61,14 +61,6 @@ class GattClient(var context: Context) {
       }
     }
 
-    override fun onPhyRead(gatt: BluetoothGatt?, txPhy: Int, rxPhy: Int, status: Int) {
-      Log.d(logTag, "Central onPhyRead: txPhy: $txPhy, rxPhy: $rxPhy, status: $status")
-    }
-
-    override fun onPhyUpdate(gatt: BluetoothGatt?, txPhy: Int, rxPhy: Int, status: Int) {
-      Log.d(logTag, "Central onPhyUpdate: txPhy: $txPhy, rxPhy: $rxPhy, status: $status")
-    }
-
     override fun onCharacteristicRead(
       gatt: BluetoothGatt?,
       characteristic: BluetoothGattCharacteristic?,
@@ -177,8 +169,6 @@ class GattClient(var context: Context) {
     // TODO: In case device is never connected, how do we know?
 
     gatt.requestConnectionPriority(CONNECTION_PRIORITY_HIGH)
-    gatt.readPhy()
-    gatt.setPreferredPhy(2, 2, 0)
     gatt.readPhy()
     this.bluetoothGatt = gatt
   }

--- a/android/src/main/java/io/mosip/tuvali/ble/peripheral/impl/GattServer.kt
+++ b/android/src/main/java/io/mosip/tuvali/ble/peripheral/impl/GattServer.kt
@@ -74,7 +74,6 @@ class GattServer(private val context: Context) : BluetoothGattServerCallback() {
       Log.i(logTag, "Connection initiated to central: $connect with device address: ${device?.address}")
 
       onDeviceConnectedCallback(status, newState)
-      device?.let { setPhy(it) }
       device
     } else {
       Log.i(logTag,"Received disconnect from central with device address: ${device?.address}")
@@ -88,14 +87,6 @@ class GattServer(private val context: Context) : BluetoothGattServerCallback() {
     val allowedMTU = min( mtu, MAX_ALLOWED_MTU_VALUE)
     Log.d(logTag, "successfully changed mtu to $allowedMTU")
     onMTUChangedCallback(allowedMTU)
-  }
-
-  private fun setPhy(bluetoothDevice: BluetoothDevice) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      gattServer.readPhy(bluetoothDevice)
-      gattServer.setPreferredPhy(bluetoothDevice, 2, 2, 0)
-      gattServer.readPhy(bluetoothDevice)
-    }
   }
 
   override fun onCharacteristicWriteRequest(
@@ -142,14 +133,6 @@ class GattServer(private val context: Context) : BluetoothGattServerCallback() {
     if (responseNeeded) {
       gattServer.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
     }
-  }
-
-  override fun onPhyRead(device: BluetoothDevice?, txPhy: Int, rxPhy: Int, status: Int) {
-    Log.d(logTag, "Peripheral onPhyRead: txPhy: $txPhy, rxPhy: $rxPhy, status: $status")
-  }
-
-  override fun onPhyUpdate(device: BluetoothDevice?, txPhy: Int, rxPhy: Int, status: Int) {
-    Log.d(logTag, "Peripheral onPhyUpdate: txPhy: $txPhy, rxPhy: $rxPhy, status: $status")
   }
 
   fun disconnect(): Boolean {


### PR DESCRIPTION
reason:

- if a preferential PHY is not requested in a connection, the BLE 5.0 chips which have issues with 2M PHY can also connect using older PHY and the responsibility of choosing a PHY is left to the firmware/OS and other entities

concerns on speed: https://github.com/mosip/tuvali/issues/52

Link: https://mosip.atlassian.net/browse/INJI-39


