### PR TITLE
fix(INJI-227): handle verifier disconnect when rejecting the current VC

### DIFF
--- a/android/src/main/java/io/mosip/tuvali/verifier/Verifier.kt
+++ b/android/src/main/java/io/mosip/tuvali/verifier/Verifier.kt
@@ -63,7 +63,7 @@ class Verifier(private val context: Context): IVerifier {
 
   private fun initializeBLECommunicator() {
     Log.d(logTag, "Initializing new verifier object at ${System.nanoTime()}")
-    communicator = VerifierBleCommunicator(context, eventEmitter, bleExceptionHandler::handleException)
+    communicator = VerifierBleCommunicator(context, eventEmitter, this::stopBLE, bleExceptionHandler::handleException)
     communicator?.generateKeyPair()
   }
 

--- a/android/src/main/java/io/mosip/tuvali/verifier/VerifierBleCommunicator.kt
+++ b/android/src/main/java/io/mosip/tuvali/verifier/VerifierBleCommunicator.kt
@@ -36,6 +36,7 @@ private const val MIN_MTU_REQUIRED = 64
 class VerifierBleCommunicator(
   context: Context,
   private val eventEmitter: EventEmitter,
+  private val onDeviceDisconnected: (()-> Unit) -> Unit,
   private val handleException: (BLEException) -> Unit
 ) :
   IPeripheralListener, ITransferListener {
@@ -224,7 +225,7 @@ class VerifierBleCommunicator(
   override fun onDeviceNotConnected(isManualDisconnect: Boolean, isConnected: Boolean) {
     Log.d(logTag, "Disconnect and is it manual: $isManualDisconnect and isConnected $isConnected")
     if (!isManualDisconnect && isConnected) {
-      stop { eventEmitter.emitEvent(DisconnectedEvent()) }
+      onDeviceDisconnected { eventEmitter.emitEvent(DisconnectedEvent()) }
     }
   }
 

--- a/android/src/main/java/io/mosip/tuvali/verifier/VerifierBleCommunicator.kt
+++ b/android/src/main/java/io/mosip/tuvali/verifier/VerifierBleCommunicator.kt
@@ -224,7 +224,7 @@ class VerifierBleCommunicator(
   override fun onDeviceNotConnected(isManualDisconnect: Boolean, isConnected: Boolean) {
     Log.d(logTag, "Disconnect and is it manual: $isManualDisconnect and isConnected $isConnected")
     if (!isManualDisconnect && isConnected) {
-      eventEmitter.emitEvent(DisconnectedEvent())
+      stop { eventEmitter.emitEvent(DisconnectedEvent()) }
     }
   }
 


### PR DESCRIPTION
- Disconnect from the verifier when rejecting the current VC share by clicking on the 'reject" button in the sharingVc screen of wallet